### PR TITLE
Remove local Payload class

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node": ">=13.10"
   },
   "dependencies": {
+    "@tvkitchen/base-classes": "^1.1.0",
     "@tvkitchen/base-errors": "^1.0.1"
   }
 }

--- a/src/Payload.js
+++ b/src/Payload.js
@@ -1,3 +1,0 @@
-class Payload {}
-
-export default Payload

--- a/src/__test__/AbstractAppliance.test.js
+++ b/src/__test__/AbstractAppliance.test.js
@@ -3,8 +3,8 @@ import {
 	AbstractInstantiationError,
 	NotImplementedError,
 } from '@tvkitchen/base-errors'
+import { Payload } from '@tvkitchen/base-classes'
 import AbstractAppliance from '../AbstractAppliance'
-import Payload from '../Payload'
 import {
 	FullyImplementedAppliance,
 	PartiallyImplementedAppliance,

--- a/src/utils/__test__/payload.test.js
+++ b/src/utils/__test__/payload.test.js
@@ -1,5 +1,5 @@
+import { Payload } from '@tvkitchen/base-classes'
 import { isPayloadInstance } from '../payload'
-import Payload from '../../Payload'
 
 describe('payload utilities #unit', () => {
 	describe('isPayloadInstance', () => {

--- a/src/utils/payload.js
+++ b/src/utils/payload.js
@@ -1,5 +1,5 @@
 // Disabling because we intend to have more exports in the future.
 /* eslint-disable import/prefer-default-export */
-import Payload from '../Payload'
+import { Payload } from '@tvkitchen/base-classes'
 
 export const isPayloadInstance = (data) => data instanceof Payload

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,6 +1012,11 @@
   dependencies:
     type-detect "4.0.8"
 
+"@tvkitchen/base-classes@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.1.0.tgz#c74d79b4b1181e529d2ed7f0eb2f62e95b9781c8"
+  integrity sha512-t0ID7KzM1mwlWtZq9cJppuLKjpSWKo2VQl6ToKRWmf2T+6SwSaayE5ThSId1gGCn4JoBITUwF6HEwMpGvxfcGw==
+
 "@tvkitchen/base-errors@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-errors/-/base-errors-1.0.1.tgz#1117e17c8a0888989ad155d1318d03b6a6ab942f"


### PR DESCRIPTION
## Description
This PR replaces the local `Payload` implementation and instead imports the `Payload` from the [@tvkitchen/base-classes](https://www.npmjs.com/package/@tvkitchen/base-classes) package.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
Related to #5 

Relies on PR #6 
