### PR TITLE
Use the IAppliance definition for AbstractAppliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@tvkitchen/base-classes": "^1.1.0",
-    "@tvkitchen/base-errors": "^1.0.1"
+    "@tvkitchen/base-errors": "^1.0.1",
+    "@tvkitchen/base-interfaces": "^1.0.1"
   }
 }

--- a/src/AbstractAppliance.js
+++ b/src/AbstractAppliance.js
@@ -1,9 +1,7 @@
 import assert from 'assert'
 import EventEmitter from 'events'
-import {
-	AbstractInstantiationError,
-	NotImplementedError,
-} from '@tvkitchen/base-errors'
+import { AbstractInstantiationError } from '@tvkitchen/base-errors'
+import { IAppliance } from '@tvkitchen/base-interfaces'
 import PayloadBuffer from './PayloadBuffer'
 import { isPayloadInstance } from './utils/payload'
 import {
@@ -12,7 +10,7 @@ import {
 } from './constants/events'
 
 /**
- * The Abstract Appliance defines the shape of an Appliance and implements
+ * The Abstract Appliance begins to implement the IAppliance interface and implements
  * a few universal pieces of functionality, such as:
  *
  * - Event emission
@@ -22,7 +20,7 @@ import {
  * For more information about the TV Kitchen architecture visit:
  * https://github.com/tvkitchen/tv-kitchen/blob/master/docs/ARCHITECTURE.md
  */
-class AbstractAppliance {
+class AbstractAppliance extends IAppliance {
 	settings = {}
 
 	emitter = new EventEmitter()
@@ -30,6 +28,7 @@ class AbstractAppliance {
 	payloadBuffer = new PayloadBuffer()
 
 	constructor(overrideSettings = {}) {
+		super()
 		if (this.constructor === AbstractAppliance) {
 			throw new AbstractInstantiationError('AbstractAppliance')
 		}
@@ -38,64 +37,6 @@ class AbstractAppliance {
 			overrideSettings,
 		)
 	}
-
-	/**
-	 *******************************************
-	 ************ ABSTRACT METHODS *************
-	 *******************************************
-	 */
-
-	/**
-	 * Getter for the list of data types accepted by the appliance.
-	 *
-	 * OVERRIDE WHEN EXTENDING
-	 *
-	 * @return {Array[String]} The list of data types accepted by the appliance.
-	 */
-	getInputTypes = () => {
-		throw new NotImplementedError('getInputTypes')
-	}
-
-	/**
-	 * Getter for the list of data types produced by the appliance.
-	 *
-	 * OVERRIDE WHEN EXTENDING
-	 *
-	 * @return {Array[String]} The list of data types produced by the appliance.
-	 */
-	getOutputTypes = () => {
-		throw new NotImplementedError('getOutputTypes')
-	}
-
-	/**
-	 * Asserts that a given payload is actually a payload.
-   *
-   * OVERRIDE WHEN EXTENDING
-   *
-	 * @param  {Payload} payload The payload that we want to validate.
-	 * @return {Boolean}         The result of the validation check.
-	 */
-	// eslint-disable-next-line no-unused-vars
-	isValidPayload = async (payload) => {
-		throw new NotImplementedError('isValidPayload')
-	}
-
-	/**
-	 * Invokes the appliance on any unprocessed data in the appliance buffer.
-   *
-   * OVERRIDE WHEN EXTENDING
-	 *
-	 * @return {Boolean} Whether or not the appliance had enough data to work with.
-	 */
-	invoke = async () => {
-		throw new NotImplementedError('invoke')
-	}
-
-	/**
-	 *******************************************
-	 *********** IMPLEMENTED METHODS ***********
-	 *******************************************
-	 */
 
 	/**
 	 * Called by a third party to pass data into the appliance.

--- a/src/__test__/AbstractAppliance.test.js
+++ b/src/__test__/AbstractAppliance.test.js
@@ -1,8 +1,5 @@
 import { AssertionError } from 'assert'
-import {
-	AbstractInstantiationError,
-	NotImplementedError,
-} from '@tvkitchen/base-errors'
+import { AbstractInstantiationError } from '@tvkitchen/base-errors'
 import { Payload } from '@tvkitchen/base-classes'
 import AbstractAppliance from '../AbstractAppliance'
 import {
@@ -12,32 +9,10 @@ import {
 
 describe('AbstractAppliance #unit', () => {
 	describe('construction', () => {
-		it('should throw an error when called directly', () => {
+		it('should throw an error when constructed directly', () => {
 			expect(() => {
 				new AbstractAppliance() // eslint-disable-line no-new
 			}).toThrow(AbstractInstantiationError)
-		})
-
-		it('should throw an error when getInputTypes() is called without implementation', () => {
-			const implementedAppliance = new PartiallyImplementedAppliance()
-			expect(() => implementedAppliance.getInputTypes()).toThrow(NotImplementedError)
-		})
-
-		it('should throw an error when getOutputTypes() is called without implementation', () => {
-			const implementedAppliance = new PartiallyImplementedAppliance()
-			expect(() => implementedAppliance.getOutputTypes()).toThrow(NotImplementedError)
-		})
-
-		it('should throw an error when isValidPayload() is called without implementation', async () => {
-			const implementedAppliance = new PartiallyImplementedAppliance()
-			await expect(async () => implementedAppliance.isValidPayload())
-				.rejects.toBeInstanceOf(NotImplementedError)
-		})
-
-		it('should throw an error when invoke() is called without implementation', async () => {
-			const implementedAppliance = new PartiallyImplementedAppliance()
-			await expect(async () => implementedAppliance.invoke())
-				.rejects.toBeInstanceOf(NotImplementedError)
 		})
 
 		it('should allow construction when extended', () => {
@@ -45,27 +20,9 @@ describe('AbstractAppliance #unit', () => {
 				new PartiallyImplementedAppliance() // eslint-disable-line no-new
 			}).not.toThrow(Error)
 		})
+	})
 
-		it('should not throw an error when getInputTypes() is called with implementation', () => {
-			const implementedAppliance = new FullyImplementedAppliance()
-			expect(() => implementedAppliance.getInputTypes()).not.toThrow(NotImplementedError)
-		})
-
-		it('should not throw an error when getOutputTypes() is called with implementation', () => {
-			const implementedAppliance = new FullyImplementedAppliance()
-			expect(() => implementedAppliance.getOutputTypes()).not.toThrow(NotImplementedError)
-		})
-
-		it('should not throw an error when isValidPayload() is called with implementation', async () => {
-			const implementedAppliance = new FullyImplementedAppliance()
-			expect(await implementedAppliance.isValidPayload()).toBeDefined()
-		})
-
-		it('should not throw an error when invoke() is called with implementation', async () => {
-			const implementedAppliance = new FullyImplementedAppliance()
-			expect(await implementedAppliance.invoke()).toBeDefined()
-		})
-
+	describe('ingestPayload', () => {
 		it('should throw an error when a non-payload is ingested', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
 			const invokeSpy = jest.spyOn(implementedAppliance, 'invoke')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,10 +1017,17 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.1.0.tgz#c74d79b4b1181e529d2ed7f0eb2f62e95b9781c8"
   integrity sha512-t0ID7KzM1mwlWtZq9cJppuLKjpSWKo2VQl6ToKRWmf2T+6SwSaayE5ThSId1gGCn4JoBITUwF6HEwMpGvxfcGw==
 
-"@tvkitchen/base-errors@^1.0.1":
+"@tvkitchen/base-errors@^1.0.0", "@tvkitchen/base-errors@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-errors/-/base-errors-1.0.1.tgz#1117e17c8a0888989ad155d1318d03b6a6ab942f"
   integrity sha512-AHb+LYbughr1dggUFiAA7y079ZRrjgLiW2KOJgeHbQXSr1kcaxcAnISUV8e1EYuUODhmN1FD8ka9T0d9+RLzKQ==
+
+"@tvkitchen/base-interfaces@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-1.0.1.tgz#27b5148b06cccb6caf670139a9ded1707adc7964"
+  integrity sha512-1Swmls6ohNi+lDKoOpvZRu1QkybgdCVfYej3ZvIE6jpM8BOkPwesH1s8LMphPnSX0XsLDU9rttyQfs2swQzKIw==
+  dependencies:
+    "@tvkitchen/base-errors" "^1.0.0"
 
 "@types/babel__core@^7.1.7":
   version "7.1.7"


### PR DESCRIPTION
## Description
This PR adds the IAppliance "interface" (really just a class because JavaScript).

This PR removes the newly redundant abstract method definitions from Abstractappliance.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
This resolves #5

Requires PR #7  to be merged before review should begin.
